### PR TITLE
Remove "are stale" log entries

### DIFF
--- a/base/checks.c
+++ b/base/checks.c
@@ -89,6 +89,7 @@ extern int      passive_host_checks_are_soft;
 
 extern int      check_service_freshness;
 extern int      log_stale_services;
+extern int      log_stale_hosts;
 extern int      check_host_freshness;
 extern int      additional_freshness_latency;
 
@@ -2652,7 +2653,7 @@ void check_host_result_freshness(void) {
 			continue;
 
 		/* the results for the last check of this host are stale */
-		if (is_host_result_fresh(temp_host, current_time, TRUE) == FALSE) {
+		if (is_host_result_fresh(temp_host, current_time, log_stale_hosts) == FALSE) {
 
 			/* set the freshen flag */
 			temp_host->is_being_freshened = TRUE;

--- a/base/checks.c
+++ b/base/checks.c
@@ -88,6 +88,7 @@ extern int      translate_passive_host_checks;
 extern int      passive_host_checks_are_soft;
 
 extern int      check_service_freshness;
+extern int      log_stale_services;
 extern int      check_host_freshness;
 extern int      additional_freshness_latency;
 
@@ -2241,7 +2242,7 @@ void check_service_result_freshness(void) {
 			continue;
 
 		/* the results for the last check of this service are stale! */
-		if (is_service_result_fresh(temp_service, current_time, TRUE) == FALSE) {
+		if (is_service_result_fresh(temp_service, current_time, log_stale_services) == FALSE) {
 
 			/* set the freshen flag */
 			temp_service->is_being_freshened = TRUE;

--- a/base/config.c
+++ b/base/config.c
@@ -127,6 +127,7 @@ extern int      check_orphaned_services;
 extern int      check_orphaned_hosts;
 extern int      check_service_freshness;
 extern int      log_stale_services;
+extern int      log_stale_hosts;
 extern int      check_host_freshness;
 extern int      auto_reschedule_checks;
 
@@ -1174,6 +1175,17 @@ int read_main_config_file(char *main_config_file) {
 			}
 
 			log_stale_services = (atoi(value) > 0) ? TRUE : FALSE;
+		}
+
+		else if (!strcmp(variable, "log_stale_hosts")) {
+
+			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
+				asprintf(&error_message, "Illegal value for log_stale_hosts");
+				error = TRUE;
+				break;
+			}
+
+			log_stale_hosts = (atoi(value) > 0) ? TRUE : FALSE;
 		}
 
 		else if (!strcmp(variable, "check_host_freshness")) {

--- a/base/config.c
+++ b/base/config.c
@@ -126,6 +126,7 @@ extern int      check_external_commands;
 extern int      check_orphaned_services;
 extern int      check_orphaned_hosts;
 extern int      check_service_freshness;
+extern int      log_stale_services;
 extern int      check_host_freshness;
 extern int      auto_reschedule_checks;
 
@@ -1162,6 +1163,17 @@ int read_main_config_file(char *main_config_file) {
 			}
 
 			check_service_freshness = (atoi(value) > 0) ? TRUE : FALSE;
+		}
+
+		else if (!strcmp(variable, "log_stale_services")) {
+
+			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
+				asprintf(&error_message, "Illegal value for log_stale_services");
+				error = TRUE;
+				break;
+			}
+
+			log_stale_services = (atoi(value) > 0) ? TRUE : FALSE;
 		}
 
 		else if (!strcmp(variable, "check_host_freshness")) {

--- a/base/icinga.c
+++ b/base/icinga.c
@@ -126,6 +126,7 @@ int             check_external_commands = DEFAULT_CHECK_EXTERNAL_COMMANDS;
 int             check_orphaned_services = DEFAULT_CHECK_ORPHANED_SERVICES;
 int             check_orphaned_hosts = DEFAULT_CHECK_ORPHANED_HOSTS;
 int             check_service_freshness = DEFAULT_CHECK_SERVICE_FRESHNESS;
+int             log_stale_services = DEFAULT_LOG_STALE_SERVICES;
 int             check_host_freshness = DEFAULT_CHECK_HOST_FRESHNESS;
 int             auto_reschedule_checks = DEFAULT_AUTO_RESCHEDULE_CHECKS;
 int             auto_rescheduling_window = DEFAULT_AUTO_RESCHEDULING_WINDOW;

--- a/base/icinga.c
+++ b/base/icinga.c
@@ -127,6 +127,7 @@ int             check_orphaned_services = DEFAULT_CHECK_ORPHANED_SERVICES;
 int             check_orphaned_hosts = DEFAULT_CHECK_ORPHANED_HOSTS;
 int             check_service_freshness = DEFAULT_CHECK_SERVICE_FRESHNESS;
 int             log_stale_services = DEFAULT_LOG_STALE_SERVICES;
+int             log_stale_hosts = DEFAULT_LOG_STALE_HOSTS;
 int             check_host_freshness = DEFAULT_CHECK_HOST_FRESHNESS;
 int             auto_reschedule_checks = DEFAULT_AUTO_RESCHEDULE_CHECKS;
 int             auto_rescheduling_window = DEFAULT_AUTO_RESCHEDULING_WINDOW;

--- a/base/utils.c
+++ b/base/utils.c
@@ -144,6 +144,7 @@ extern int      check_external_commands;
 extern int      check_orphaned_services;
 extern int      check_orphaned_hosts;
 extern int      check_service_freshness;
+extern int      log_stale_services;
 extern int      check_host_freshness;
 extern int      auto_reschedule_checks;
 
@@ -4558,6 +4559,7 @@ int reset_variables(void) {
 	check_orphaned_services = DEFAULT_CHECK_ORPHANED_SERVICES;
 	check_orphaned_hosts = DEFAULT_CHECK_ORPHANED_HOSTS;
 	check_service_freshness = DEFAULT_CHECK_SERVICE_FRESHNESS;
+	log_stale_services = DEFAULT_LOG_STALE_SERVICES;
 	check_host_freshness = DEFAULT_CHECK_HOST_FRESHNESS;
 	auto_reschedule_checks = DEFAULT_AUTO_RESCHEDULE_CHECKS;
 

--- a/base/utils.c
+++ b/base/utils.c
@@ -145,6 +145,7 @@ extern int      check_orphaned_services;
 extern int      check_orphaned_hosts;
 extern int      check_service_freshness;
 extern int      log_stale_services;
+extern int      log_stale_hosts;
 extern int      check_host_freshness;
 extern int      auto_reschedule_checks;
 
@@ -4560,6 +4561,7 @@ int reset_variables(void) {
 	check_orphaned_hosts = DEFAULT_CHECK_ORPHANED_HOSTS;
 	check_service_freshness = DEFAULT_CHECK_SERVICE_FRESHNESS;
 	log_stale_services = DEFAULT_LOG_STALE_SERVICES;
+	log_stale_hosts = DEFAULT_LOG_STALE_HOSTS;
 	check_host_freshness = DEFAULT_CHECK_HOST_FRESHNESS;
 	auto_reschedule_checks = DEFAULT_AUTO_RESCHEDULE_CHECKS;
 

--- a/include/icinga.h
+++ b/include/icinga.h
@@ -117,8 +117,8 @@ extern "C" {
 #define DEFAULT_ENABLE_FLAP_DETECTION           		0       /* don't enable flap detection */
 #define DEFAULT_PROCESS_PERFORMANCE_DATA        		0       /* don't process performance data */
 #define DEFAULT_CHECK_SERVICE_FRESHNESS         		1       /* check service result freshness */
-#define DEFAULT_LOG_STALE_SERVICES                  1       /* log stale services messages */
-#define DEFAULT_LOG_STALE_HOSTS                     1       /* log stale hosts messages */
+#define DEFAULT_LOG_STALE_SERVICES              		1       /* log stale services messages */
+#define DEFAULT_LOG_STALE_HOSTS                 		1       /* log stale hosts messages */
 #define DEFAULT_CHECK_HOST_FRESHNESS            		0       /* don't check host result freshness */
 #define DEFAULT_AUTO_RESCHEDULE_CHECKS          		0       /* don't auto-reschedule host and service checks */
 #define DEFAULT_TRANSLATE_PASSIVE_HOST_CHECKS                   0       /* should we translate DOWN/UNREACHABLE passive host checks? */

--- a/include/icinga.h
+++ b/include/icinga.h
@@ -117,7 +117,8 @@ extern "C" {
 #define DEFAULT_ENABLE_FLAP_DETECTION           		0       /* don't enable flap detection */
 #define DEFAULT_PROCESS_PERFORMANCE_DATA        		0       /* don't process performance data */
 #define DEFAULT_CHECK_SERVICE_FRESHNESS         		1       /* check service result freshness */
-#define DEFAULT_LOG_STALE_SERVICES                  1       /* log stale messages */
+#define DEFAULT_LOG_STALE_SERVICES                  1       /* log stale services messages */
+#define DEFAULT_LOG_STALE_HOSTS                     1       /* log stale hosts messages */
 #define DEFAULT_CHECK_HOST_FRESHNESS            		0       /* don't check host result freshness */
 #define DEFAULT_AUTO_RESCHEDULE_CHECKS          		0       /* don't auto-reschedule host and service checks */
 #define DEFAULT_TRANSLATE_PASSIVE_HOST_CHECKS                   0       /* should we translate DOWN/UNREACHABLE passive host checks? */

--- a/include/icinga.h
+++ b/include/icinga.h
@@ -117,6 +117,7 @@ extern "C" {
 #define DEFAULT_ENABLE_FLAP_DETECTION           		0       /* don't enable flap detection */
 #define DEFAULT_PROCESS_PERFORMANCE_DATA        		0       /* don't process performance data */
 #define DEFAULT_CHECK_SERVICE_FRESHNESS         		1       /* check service result freshness */
+#define DEFAULT_LOG_STALE_SERVICES                  1       /* log stale messages */
 #define DEFAULT_CHECK_HOST_FRESHNESS            		0       /* don't check host result freshness */
 #define DEFAULT_AUTO_RESCHEDULE_CHECKS          		0       /* don't auto-reschedule host and service checks */
 #define DEFAULT_TRANSLATE_PASSIVE_HOST_CHECKS                   0       /* should we translate DOWN/UNREACHABLE passive host checks? */

--- a/sample-config/icinga.cfg.in
+++ b/sample-config/icinga.cfg.in
@@ -1156,6 +1156,14 @@ check_service_freshness=1
 
 
 
+# STALE SERVICES LOGGING OPTION
+# If you don't want notifications to be logged, set this value to 0.
+# If notifications should be logged, set the value to 1.
+
+log_stale_services=1
+
+
+
 # SERVICE FRESHNESS CHECK INTERVAL
 # This setting determines how often (in seconds) Icinga will
 # check the "freshness" of service check results.  If you have

--- a/sample-config/icinga.cfg.in
+++ b/sample-config/icinga.cfg.in
@@ -1164,6 +1164,15 @@ log_stale_services=1
 
 
 
+# STALE HOSTS LOGGING OPTION
+# If you don't want notifications to be logged, set this value to 0.
+# If notifications should be logged, set the value to 1.
+
+log_stale_hosts=1
+
+
+
+
 # SERVICE FRESHNESS CHECK INTERVAL
 # This setting determines how often (in seconds) Icinga will
 # check the "freshness" of service check results.  If you have


### PR DESCRIPTION
This PR is to be able to deactivate this log entries:

```
[1460561008] Warning: The results of service 'check_users' on host 'HOSTNAME' are stale by 0d 0h 0m 27s (threshold=0d 0h 2m 30s).  I'm forcing an immediate check of the service.
```

I have define a new parameter `log_stale_services` to disable that lines.

We have a large environment with passive checks and those lines represents the 98% of the icinga.log file, that reachs 1800000 lines per day.
