### PR TITLE
Fix database upgrade to 1.13.0 with old schema.

### DIFF
--- a/module/idoutils/db/pgsql/upgrade/pgsql-upgrade-1.13.0.sql
+++ b/module/idoutils/db/pgsql/upgrade/pgsql-upgrade-1.13.0.sql
@@ -11,8 +11,11 @@
 -- #7765 drop unique constraint
 -- -----------------------------------------
 
-ALTER TABLE icinga_servicedependencies DROP CONSTRAINT uq_servicedependencies;
-ALTER TABLE icinga_hostdependencies DROP CONSTRAINT uq_hostdependencies;
+ALTER TABLE icinga_servicedependencies DROP CONSTRAINT IF EXISTS icinga_servicedependencies_instance_id_key;
+ALTER TABLE icinga_hostdependencies DROP CONSTRAINT IF EXISTS icinga_hostdependencies_instance_id_key;
+
+ALTER TABLE icinga_servicedependencies DROP CONSTRAINT IF EXISTS UQ_servicedependencies;
+ALTER TABLE icinga_hostdependencies DROP CONSTRAINT IF EXISTS UQ_hostdependencies;
 
 CREATE INDEX idx_servicedependencies ON icinga_servicedependencies(instance_id,config_type,service_object_id,dependent_service_object_id,dependency_type,inherits_parent,fail_on_ok,fail_on_warning,fail_on_unknown,fail_on_critical);
 CREATE INDEX idx_hostdependencies ON icinga_hostdependencies(instance_id,config_type,host_object_id,dependent_host_object_id,dependency_type,inherits_parent,fail_on_up,fail_on_down,fail_on_unreachable);


### PR DESCRIPTION
As reported by Andreas Beckmann in [Debian Bug #861077](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=861077), applying the `pgsql-upgrade-1.13.0.sql` upgrade script fails when the database was created with an old schema (1.0.2 in this case):
```
ERROR: constraint "uq_servicedependencies" of relation "icinga_servicedependencies" does not exist
```
The old `pgsql.sql` script didn't create the UNIQUE CONSTRAINT with an explicit name as expected by the upgrade script.

Using `DROP CONSTRAINT ... IF EXISTS` solves this issue, along with conditionally dropping the automatically named constraint from the old schema.