### PR TITLE
List host alerts in Most Recent Alerts report. Fix #1599.

### DIFF
--- a/cgi/summary.c
+++ b/cgi/summary.c
@@ -1618,7 +1618,7 @@ void display_recent_alerts(void) {
 			continue;
 
 		/* find the service */
-		if ((temp_service = find_service(temp_event->host_name, temp_event->service_description)) == NULL)
+		if (temp_event->event_type != AE_HOST_ALERT && (temp_service = find_service(temp_event->host_name, temp_event->service_description)) == NULL)
 			continue;
 
 		get_time_string(&temp_event->time_stamp, date_time, (int)sizeof(date_time), SHORT_DATE_TIME);


### PR DESCRIPTION
In add_archived_event(), service_description is set to NULL for events
of type AE_HOST_ALERT. Later on in display_recent_alerts(), all events
without service_description are skipped. But it's ok for host alerts
to have no related service. We're even prepared to write "N/A" to
the reports service column. So skip events only if they're actually
a service alert.

Seems to be a regression introduced with commit a4f01c32a4cfc04430476741e0cbaa30a80310ee.