### PR TITLE
Fix source installation permissions (CVE-2017-16882, packages not affected)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -369,13 +369,13 @@ install:
 	cd $(SRC_HTM) && $(MAKE) $@
 
 	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(STATEDIR)
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(LIBEXECDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(LIBEXECDIR)
 	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(LOGDIR)
 	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(LOGDIR)/archives
 	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CHECKRESULTDIR)
 	if [ $(INSTALLPERLSTUFF) = yes ]; then \
-		$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(P1FILELOC); \
-		$(INSTALL) -m 664 $(INSTALL_OPTS) p1.pl $(DESTDIR)$(P1FILELOC); \
+		$(INSTALL) -m 775 -d $(DESTDIR)$(P1FILELOC); \
+		$(INSTALL) -m 664 p1.pl $(DESTDIR)$(P1FILELOC); \
 	fi;
 
 	@echo ""
@@ -417,30 +417,30 @@ install:
 	@echo ""
 
 install-cgiconf:
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CFGDIR)
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/cgi.cfg $(DESTDIR)$(CFGDIR)/cgi.cfg
+	$(INSTALL) -m 775 -d $(DESTDIR)$(CFGDIR)
+	$(INSTALL) -b -m 664 sample-config/cgi.cfg $(DESTDIR)$(CFGDIR)/cgi.cfg
 
 
 install-config: install-cgiconf
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CFGDIR)
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CFGDIR)/objects
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CFGDIR)/conf.d
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CFGDIR)/modules
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/icinga.cfg $(DESTDIR)$(CFGDIR)/icinga.cfg
-	$(INSTALL) -b -m 660 $(INSTALL_OPTS) sample-config/resource.cfg $(DESTDIR)$(CFGDIR)/resource.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/template-object/templates.cfg $(DESTDIR)$(CFGDIR)/objects/templates.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/template-object/commands.cfg $(DESTDIR)$(CFGDIR)/objects/commands.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/template-object/contacts.cfg $(DESTDIR)$(CFGDIR)/objects/contacts.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/template-object/notifications.cfg $(DESTDIR)$(CFGDIR)/objects/notifications.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/template-object/timeperiods.cfg $(DESTDIR)$(CFGDIR)/objects/timeperiods.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/template-object/localhost.cfg $(DESTDIR)$(CFGDIR)/objects/localhost.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/template-object/windows.cfg $(DESTDIR)$(CFGDIR)/objects/windows.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/template-object/printer.cfg $(DESTDIR)$(CFGDIR)/objects/printer.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/template-object/switch.cfg $(DESTDIR)$(CFGDIR)/objects/switch.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/modules/livestatus.cfg $(DESTDIR)$(CFGDIR)/modules/livestatus.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/modules/mod_gearman.cfg $(DESTDIR)$(CFGDIR)/modules/mod_gearman.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/modules/pnp4nagios.cfg $(DESTDIR)$(CFGDIR)/modules/pnp4nagios.cfg
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) sample-config/modules/flapjack.cfg $(DESTDIR)$(CFGDIR)/modules/flapjack.cfg
+	$(INSTALL) -m 775 -d $(DESTDIR)$(CFGDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(CFGDIR)/objects
+	$(INSTALL) -m 775 -d $(DESTDIR)$(CFGDIR)/conf.d
+	$(INSTALL) -m 775 -d $(DESTDIR)$(CFGDIR)/modules
+	$(INSTALL) -b -m 664 sample-config/icinga.cfg $(DESTDIR)$(CFGDIR)/icinga.cfg
+	$(INSTALL) -b -m 660 sample-config/resource.cfg $(DESTDIR)$(CFGDIR)/resource.cfg
+	$(INSTALL) -b -m 664 sample-config/template-object/templates.cfg $(DESTDIR)$(CFGDIR)/objects/templates.cfg
+	$(INSTALL) -b -m 664 sample-config/template-object/commands.cfg $(DESTDIR)$(CFGDIR)/objects/commands.cfg
+	$(INSTALL) -b -m 664 sample-config/template-object/contacts.cfg $(DESTDIR)$(CFGDIR)/objects/contacts.cfg
+	$(INSTALL) -b -m 664 sample-config/template-object/notifications.cfg $(DESTDIR)$(CFGDIR)/objects/notifications.cfg
+	$(INSTALL) -b -m 664 sample-config/template-object/timeperiods.cfg $(DESTDIR)$(CFGDIR)/objects/timeperiods.cfg
+	$(INSTALL) -b -m 664 sample-config/template-object/localhost.cfg $(DESTDIR)$(CFGDIR)/objects/localhost.cfg
+	$(INSTALL) -b -m 664 sample-config/template-object/windows.cfg $(DESTDIR)$(CFGDIR)/objects/windows.cfg
+	$(INSTALL) -b -m 664 sample-config/template-object/printer.cfg $(DESTDIR)$(CFGDIR)/objects/printer.cfg
+	$(INSTALL) -b -m 664 sample-config/template-object/switch.cfg $(DESTDIR)$(CFGDIR)/objects/switch.cfg
+	$(INSTALL) -b -m 664 sample-config/modules/livestatus.cfg $(DESTDIR)$(CFGDIR)/modules/livestatus.cfg
+	$(INSTALL) -b -m 664 sample-config/modules/mod_gearman.cfg $(DESTDIR)$(CFGDIR)/modules/mod_gearman.cfg
+	$(INSTALL) -b -m 664 sample-config/modules/pnp4nagios.cfg $(DESTDIR)$(CFGDIR)/modules/pnp4nagios.cfg
+	$(INSTALL) -b -m 664 sample-config/modules/flapjack.cfg $(DESTDIR)$(CFGDIR)/modules/flapjack.cfg
 
 	@echo ""
 	@echo "*** Config files installed ***"
@@ -451,14 +451,14 @@ install-config: install-cgiconf
 	@echo ""
 
 install-testconfig:
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CFGDIR)/tests
+	$(INSTALL) -m 775 -d $(DESTDIR)$(CFGDIR)/tests
 	for file in tests/etc/*.cfg; \
-	do $(INSTALL) -b -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(CFGDIR)/tests; done
+	do $(INSTALL) -b -m 664 $$file $(DESTDIR)$(CFGDIR)/tests; done
 
 
 install-webconf:
 	$(MKDIR) -p -m 775 $(DESTDIR)$(HTTPD_CONF)
-	$(INSTALL) -b -m 644 $(INSTALL_OPTS) sample-config/httpd.conf $(DESTDIR)$(HTTPDCONFFILE)
+	$(INSTALL) -b -m 644 sample-config/httpd.conf $(DESTDIR)$(HTTPDCONFFILE)
 	@if [ x$(APACHE24_DEBIAN) = xyes ]; then \
 		echo " Debian Apache 2.4 detected. " ;\
 		echo " Run 'a2enconf icinga' and 'service apache2 reload'" ;\
@@ -470,7 +470,8 @@ install-webconf:
 
 install-webconf-auth:
 	$(MKDIR) -p -m 775 $(DESTDIR)$(HTTPD_CONF)
-	$(INSTALL) -b -m 644 $(INSTALL_OPTS) icinga.htpasswd $(DESTDIR)$(HTTPAUTHFILE)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(CFGDIR)
+	$(INSTALL) -b -m 644 icinga.htpasswd $(DESTDIR)$(HTTPAUTHFILE)
 
 	@echo ""
 	@echo "*** Icinga http auth file installed ***"
@@ -528,27 +529,27 @@ install-commandmode:
 	@echo ""
 
 install-eventhandlers:
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(EVENTHANDLERDIR)
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(EVENTHANDLERDIR)/distributed-monitoring
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(EVENTHANDLERDIR)/redundancy-scenario1
-	$(INSTALL) -b -m 774 $(INSTALL_OPTS) contrib/eventhandlers/submit_check_result $(DESTDIR)$(EVENTHANDLERDIR)/submit_check_result
-	$(INSTALL) -b -m 774 $(INSTALL_OPTS) contrib/eventhandlers/disable_active_service_checks $(DESTDIR)$(EVENTHANDLERDIR)/disable_active_service_checks
-	$(INSTALL) -b -m 774 $(INSTALL_OPTS) contrib/eventhandlers/enable_active_service_checks $(DESTDIR)$(EVENTHANDLERDIR)/enable_active_service_checks
-	$(INSTALL) -b -m 774 $(INSTALL_OPTS) contrib/eventhandlers/disable_notifications $(DESTDIR)$(EVENTHANDLERDIR)/disable_notifications
-	$(INSTALL) -b -m 774 $(INSTALL_OPTS) contrib/eventhandlers/enable_notifications $(DESTDIR)$(EVENTHANDLERDIR)/enable_notifications
-	$(INSTALL) -b -m 774 $(INSTALL_OPTS) contrib/eventhandlers/distributed-monitoring/obsessive_svc_handler $(DESTDIR)$(EVENTHANDLERDIR)/distributed-monitoring/obsessive_svc_handler
-	$(INSTALL) -b -m 774 $(INSTALL_OPTS) contrib/eventhandlers/distributed-monitoring/submit_check_result_via_nsca $(DESTDIR)$(EVENTHANDLERDIR)/distributed-monitoring/submit_check_result_via_nsca
-	$(INSTALL) -b -m 774 $(INSTALL_OPTS) contrib/eventhandlers/redundancy-scenario1/handle-master-host-event $(DESTDIR)$(EVENTHANDLERDIR)/redundancy-scenario1/handle-master-host-event
-	$(INSTALL) -b -m 774 $(INSTALL_OPTS) contrib/eventhandlers/redundancy-scenario1/handle-master-proc-event $(DESTDIR)$(EVENTHANDLERDIR)/redundancy-scenario1/handle-master-proc-event
+	$(INSTALL) -m 775 -d $(DESTDIR)$(EVENTHANDLERDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(EVENTHANDLERDIR)/distributed-monitoring
+	$(INSTALL) -m 775 -d $(DESTDIR)$(EVENTHANDLERDIR)/redundancy-scenario1
+	$(INSTALL) -b -m 775 contrib/eventhandlers/submit_check_result $(DESTDIR)$(EVENTHANDLERDIR)/submit_check_result
+	$(INSTALL) -b -m 775 contrib/eventhandlers/disable_active_service_checks $(DESTDIR)$(EVENTHANDLERDIR)/disable_active_service_checks
+	$(INSTALL) -b -m 775 contrib/eventhandlers/enable_active_service_checks $(DESTDIR)$(EVENTHANDLERDIR)/enable_active_service_checks
+	$(INSTALL) -b -m 775 contrib/eventhandlers/disable_notifications $(DESTDIR)$(EVENTHANDLERDIR)/disable_notifications
+	$(INSTALL) -b -m 775 contrib/eventhandlers/enable_notifications $(DESTDIR)$(EVENTHANDLERDIR)/enable_notifications
+	$(INSTALL) -b -m 775 contrib/eventhandlers/distributed-monitoring/obsessive_svc_handler $(DESTDIR)$(EVENTHANDLERDIR)/distributed-monitoring/obsessive_svc_handler
+	$(INSTALL) -b -m 775 contrib/eventhandlers/distributed-monitoring/submit_check_result_via_nsca $(DESTDIR)$(EVENTHANDLERDIR)/distributed-monitoring/submit_check_result_via_nsca
+	$(INSTALL) -b -m 775 contrib/eventhandlers/redundancy-scenario1/handle-master-host-event $(DESTDIR)$(EVENTHANDLERDIR)/redundancy-scenario1/handle-master-host-event
+	$(INSTALL) -b -m 775 contrib/eventhandlers/redundancy-scenario1/handle-master-proc-event $(DESTDIR)$(EVENTHANDLERDIR)/redundancy-scenario1/handle-master-proc-event
 
 	@echo ""
 	@echo "*** Sample Eventhandlers installed ***"
 	@echo ""
 
 install-downtimes:
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(DOWNTIMESDIR)
-	$(INSTALL) -b -m 774 $(INSTALL_OPTS) tools/downtimes/sched_down.pl $(DESTDIR)$(DOWNTIMESDIR)/sched_down.pl
-	$(INSTALL) -b -m 774 $(INSTALL_OPTS) tools/downtimes/sched_conv.pl $(DESTDIR)$(DOWNTIMESDIR)/sched_conv.pl
+	$(INSTALL) -m 775 -d $(DESTDIR)$(DOWNTIMESDIR)
+	$(INSTALL) -b -m 775 tools/downtimes/sched_down.pl $(DESTDIR)$(DOWNTIMESDIR)/sched_down.pl
+	$(INSTALL) -b -m 775 tools/downtimes/sched_conv.pl $(DESTDIR)$(DOWNTIMESDIR)/sched_conv.pl
 
 	@echo ""
 	@echo "*** Recurring downtimes scripts installed ***"

--- a/base/Makefile.in
+++ b/base/Makefile.in
@@ -185,5 +185,5 @@ devclean: distclean
 install:
 	$(INSTALL) -m 755 -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 755 -d $(DESTDIR)$(LIBDIR)
-	$(INSTALL) -m 755 $(INSTALL_OPTS) @icinga_name@ $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 755 $(INSTALL_OPTS) @icingastats_name@ $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 755 @icinga_name@ $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 755 @icingastats_name@ $(DESTDIR)$(BINDIR)

--- a/cgi/Makefile.in
+++ b/cgi/Makefile.in
@@ -185,7 +185,7 @@ devclean: distclean
 
 install:
 	$(INSTALL) -m 775 $(INSTALL_OPTS_WEB) -d $(DESTDIR)$(CGILOGDIR)
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CGIDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(CGIDIR)
 	for file in *.cgi; do \
-		$(INSTALL) -m 775 $(INSTALL_OPTS) $$file $(DESTDIR)$(CGIDIR); \
+		$(INSTALL) -m 775 $$file $(DESTDIR)$(CGIDIR); \
 	done

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -56,8 +56,8 @@ distclean: clean
 devclean: distclean
 
 install:
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(BINDIR)
-	for f in $(UTILS); do $(INSTALL) -m 775 $(INSTALL_OPTS) $$f $(DESTDIR)$(BINDIR); done
+	$(INSTALL) -m 775 -d $(DESTDIR)$(BINDIR)
+	for f in $(UTILS); do $(INSTALL) -m 775 $$f $(DESTDIR)$(BINDIR); done
 
 ##############################################################################
 # rules and dependencies for actual target programs

--- a/html/Makefile.in
+++ b/html/Makefile.in
@@ -35,86 +35,86 @@ distclean: clean
 devclean: distclean
 
 install:
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/media
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/stylesheets
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/docs
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/docs/stylesheets
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/docs/js
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/docs/en
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/docs/de
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/docs/images
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/docs/images/flags
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/images
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/images/logos
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/images/logos/equipment
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/images/logos/hardware
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/images/logos/other
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/images/logos/vendors
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/jquery-ui
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/jquery-ui/themes
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/jquery-ui/themes/base
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/jquery-ui/themes/base/images
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/jquery-ui/ui
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/jquery-ui/ui/minified
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/jquery-ui-addon
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/js
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/ssi
-	$(INSTALL) -m 444 $(INSTALL_OPTS) log/.htaccess $(DESTDIR)$(CGILOGDIR)
-	$(INSTALL) -m 644 $(INSTALL_OPTS) log/index.htm $(DESTDIR)$(CGILOGDIR)
-	$(INSTALL) -m 664 $(INSTALL_OPTS) robots.txt $(DESTDIR)$(HTMLDIR)
-	$(INSTALL) -m 664 $(INSTALL_OPTS) docs/robots.txt $(DESTDIR)$(HTMLDIR)/docs
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/media
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/stylesheets
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/docs
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/docs/stylesheets
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/docs/js
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/docs/en
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/docs/de
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/docs/images
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/docs/images/flags
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/images
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/images/logos
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/images/logos/equipment
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/images/logos/hardware
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/images/logos/other
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/images/logos/vendors
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/jquery-ui
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/jquery-ui/themes
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/jquery-ui/themes/base
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/jquery-ui/themes/base/images
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/jquery-ui/ui
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/jquery-ui/ui/minified
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/jquery-ui-addon
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/js
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/ssi
+	$(INSTALL) -m 444 log/.htaccess $(DESTDIR)$(CGILOGDIR)
+	$(INSTALL) -m 644 log/index.htm $(DESTDIR)$(CGILOGDIR)
+	$(INSTALL) -m 664 robots.txt $(DESTDIR)$(HTMLDIR)
+	$(INSTALL) -m 664 docs/robots.txt $(DESTDIR)$(HTMLDIR)/docs
 	for file in *.html; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR); done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR); done
 	for file in stylesheets/*.css; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/stylesheets; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/stylesheets; done
 	for file in docs/*.html; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/docs; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/docs; done
 	for file in docs/js/*.js; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/docs/js; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/docs/js; done
 	for file in docs/stylesheets/*.css; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/docs/stylesheets; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/docs/stylesheets; done
 	for file in docs/en/*.html; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/docs/en; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/docs/en; done
 	for file in docs/de/*.html; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/docs/de; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/docs/de; done
 	for file in docs/images/*.*; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/docs/images; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/docs/images; done
 	for file in docs/images/flags/*.*; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/docs/images/flags; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/docs/images/flags; done
 	for file in images/*.png; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/images; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/images; done
 	for file in images/*.jpg; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/images; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/images; done
 	for file in images/*.gif; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/images; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/images; done
 	for file in images/*.ico; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/images; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/images; done
 	for file in images/logos/*.*; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/images/logos; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/images/logos; done
 	for file in images/logos/equipment/*.*; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/images/logos/equipment; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/images/logos/equipment; done
 	for file in images/logos/hardware/*.*; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/images/logos/hardware; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/images/logos/hardware; done
 	for file in images/logos/other/*.*; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/images/logos/other; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/images/logos/other; done
 	for file in images/logos/vendors/*.*; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/images/logos/vendors; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/images/logos/vendors; done
 	for file in jquery-ui/ui/minified/*.js; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/jquery-ui/ui/minified; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/jquery-ui/ui/minified; done
 	for file in jquery-ui/themes/base/*.css; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/jquery-ui/themes/base; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/jquery-ui/themes/base; done
 	for file in jquery-ui/themes/base/images/*.png; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/jquery-ui/themes/base/images; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/jquery-ui/themes/base/images; done
 	for file in jquery-ui-addon/*.*; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/jquery-ui-addon; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/jquery-ui-addon; done
 	for file in js/*.js; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/js; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/js; done
 
 install-dev-docu:
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/doxygen
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(HTMLDIR)/doxygen/html
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/doxygen
+	$(INSTALL) -m 775 -d $(DESTDIR)$(HTMLDIR)/doxygen/html
 	#for file in doxygen/*.*; \
-	#do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/doxygen; done
+	#do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/doxygen; done
 	for file in doxygen/html/*.*; \
-	do $(INSTALL) -m 664 $(INSTALL_OPTS) $$file $(DESTDIR)$(HTMLDIR)/doxygen/html; done
+	do $(INSTALL) -m 664 $$file $(DESTDIR)$(HTMLDIR)/doxygen/html; done

--- a/module/idoutils/Makefile.in
+++ b/module/idoutils/Makefile.in
@@ -54,11 +54,11 @@ install-idoutils: install
 
 install: 
 	cd $(SRC_BASE) && $(MAKE) $@
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CFGDIR)
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CFGDIR)/objects
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CFGDIR)/modules
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) config/ido2db.cfg-sample $(DESTDIR)$(CFGDIR)
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) config/idomod.cfg-sample $(DESTDIR)$(CFGDIR)
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) config/idoutils.cfg-sample $(DESTDIR)$(CFGDIR)/modules
-	$(INSTALL) -b -m 664 $(INSTALL_OPTS) config/ido2db_check_proc.cfg $(DESTDIR)$(CFGDIR)/objects/ido2db_check_proc.cfg
+	$(INSTALL) -m 775 -d $(DESTDIR)$(CFGDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(CFGDIR)/objects
+	$(INSTALL) -m 775 -d $(DESTDIR)$(CFGDIR)/modules
+	$(INSTALL) -b -m 664 config/ido2db.cfg-sample $(DESTDIR)$(CFGDIR)
+	$(INSTALL) -b -m 664 config/idomod.cfg-sample $(DESTDIR)$(CFGDIR)
+	$(INSTALL) -b -m 664 config/idoutils.cfg-sample $(DESTDIR)$(CFGDIR)/modules
+	$(INSTALL) -b -m 664 config/ido2db_check_proc.cfg $(DESTDIR)$(CFGDIR)/objects/ido2db_check_proc.cfg
 

--- a/module/idoutils/src/Makefile.in
+++ b/module/idoutils/src/Makefile.in
@@ -113,9 +113,9 @@ distclean: clean
 devclean: distclean
 
 install:
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(LIBDIR)
-	$(INSTALL) -m 755 $(INSTALL_OPTS) ido2db $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 755 $(INSTALL_OPTS) log2ido $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 755 $(INSTALL_OPTS) idomod.so $(DESTDIR)$(LIBDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(LIBDIR)
+	$(INSTALL) -m 755 ido2db $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 755 log2ido $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 755 idomod.so $(DESTDIR)$(LIBDIR)
 


### PR DESCRIPTION
This fixes CVE-2017-16882

Packages are not affected, they always set INSTALL_OPTS='' and use
their own safe permissions.

fixes #1601