### PR TITLE
Fix crashes when some external APIs fail

### DIFF
--- a/base/logging.c
+++ b/base/logging.c
@@ -606,7 +606,10 @@ int rotate_log_file(time_t rotation_time) {
 
 	if (stat_result == 0) {
 		chmod(log_file, log_file_stat.st_mode);
-		chown(log_file, log_file_stat.st_uid, log_file_stat.st_gid);
+		if (chown(log_file, log_file_stat.st_uid, log_file_stat.st_gid) < 0) {
+			perror("chown failed");
+			return ERROR;
+		}
 	}
 
 	/* log current host and service state if activated*/

--- a/cgi/cgiutils.c
+++ b/cgi/cgiutils.c
@@ -3047,7 +3047,10 @@ int rotate_cgi_log_file() {
 
 	if (stat_result == 0) {
 		chmod(cgi_log_file, log_file_stat.st_mode);
-		chown(cgi_log_file, log_file_stat.st_uid, log_file_stat.st_gid);
+		if (chown(cgi_log_file, log_file_stat.st_uid, log_file_stat.st_gid) < 0) {
+			perror("chown failed");
+			return ERROR;
+		}
 	}
 
 	my_free(log_archive);


### PR DESCRIPTION
Hi,

I'm a PhD student. I analyzed the icinga source code and found some potential API bugs that may cause crashes.
These crashes are mainly caused by insufficient error handling of API functions like chown, chdir or pipe.
I think it's unsafe to assume the library function would be correct. It would be better if we could handle the error properly.

Best,
Zhouyang